### PR TITLE
Fixed typographical error, changed auxilary to auxiliary in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ vera is an extension to [wq.db], the database component of the [wq framework].  
 
 # Models
 
-The core of vera is a collection of [Django models] that describe the various components of the ERAV data model.  There are four primary models (ERAV) and three auxilary models, for a total of seven models.  The mapping from vera models to their ERAV conceptual equivalents is below:
+The core of vera is a collection of [Django models] that describe the various components of the ERAV data model.  There are four primary models (ERAV) and three auxiliary models, for a total of seven models.  The mapping from vera models to their ERAV conceptual equivalents is below:
 
 vera model | ERAV equivalent
 -----|------


### PR DESCRIPTION
wq, I've corrected a typographical error in the documentation of the [vera](https://github.com/wq/vera) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
