### PR TITLE
Don't html-escape labels

### DIFF
--- a/vera/params/models.py
+++ b/vera/params/models.py
@@ -30,7 +30,7 @@ class BaseParameter(patterns.IdentifiedModel):
     is_numeric = models.BooleanField(default=False)
     units = models.CharField(max_length=50, null=True, blank=True)
 
-    wq_label_template = "{{name}}{{#units}} ({{units}}){{/units}}"
+    wq_label_template = "{{{name}}}{{#units}} ({{{units}}}){{/units}}"
 
     class Meta(patterns.IdentifiedModel.Meta):
         abstract = True

--- a/vera/series/models.py
+++ b/vera/series/models.py
@@ -42,7 +42,7 @@ class BaseEvent(NaturalKeyModel, LabelModel):
     def is_valid(self):
         return self.valid_reports.count() > 0
 
-    wq_label_template = "{{site.slug}} Event"
+    wq_label_template = "{{{site.slug}}} Event"
 
     class Meta:
         abstract = True
@@ -119,7 +119,7 @@ class BaseReport(LabelModel):
         super(BaseReport, self).save(*args, **kwargs)
 
     wq_label_template = (
-        "{{#event}}Report for {{site.slug}} Event{{/event}}"
+        "{{#event}}Report for {{{site.slug}}} Event{{/event}}"
         "{{^event}}New Report{{/event}}"
     )
 
@@ -132,7 +132,7 @@ class BaseReport(LabelModel):
 class Event(BaseEvent):
     date = models.DateField()
 
-    wq_label_template = "{{site.slug}} on {{date}}"
+    wq_label_template = "{{{site.slug}}} on {{{date}}}"
 
     class Meta(BaseEvent.Meta):
         db_table = 'wq_event'
@@ -143,7 +143,7 @@ class Event(BaseEvent):
 
 class Report(BaseReport):
     wq_label_template = (
-        "{{#event}}Report for {{site.slug}} on {{date}}{{/event}}"
+        "{{#event}}Report for {{{site.slug}}} on {{{date}}}{{/event}}"
         "{{^event}}New Report{{/event}}"
     )
 


### PR DESCRIPTION
In reports/new.json parameter labels are being html-escaped.  Fix it so
that the labels are left unescaped.  Then mustache can do it's normal
job of escaping the html